### PR TITLE
Add configurable video devices with existence checking

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,5 +10,9 @@
     "video_resolution": "1280x720",
     "frame_rate": 30,
     "num_cameras": 2
-  }
+  },
+  "video_devices": [
+    "/dev/video0",
+    "/dev/video1"
+  ]
 }

--- a/parallel2video_ffmpeg.sh
+++ b/parallel2video_ffmpeg.sh
@@ -31,11 +31,66 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     echo "  - ffmpeg"
     echo "  - GNU parallel"
     echo "  - figlet"
-    echo "  - Two video devices at /dev/video0 and /dev/video1"
+    echo "  - jq"
+    echo "  - Video devices configured in config.json"
     echo ""
     echo "Press Ctrl+C to stop recording."
     exit 0
 fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/config.json"
+
+# Check video devices from config
+echo "Checking video devices..."
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "❌ Config file not found: $CONFIG_FILE"
+    exit 1
+fi
+
+# Read video devices from config
+mapfile -t WANTED_DEVICES < <(jq -r '.video_devices[]' "$CONFIG_FILE" 2>/dev/null)
+if [ ${#WANTED_DEVICES[@]} -eq 0 ]; then
+    echo "❌ No video devices configured in config.json"
+    exit 1
+fi
+
+# Check which devices exist
+AVAILABLE_DEVICES=()
+MISSING_DEVICES=()
+for device in "${WANTED_DEVICES[@]}"; do
+    if [ -e "$device" ]; then
+        AVAILABLE_DEVICES+=("$device")
+        echo "✅ Found: $device"
+    else
+        MISSING_DEVICES+=("$device")
+        echo "❌ Missing: $device"
+    fi
+done
+
+# Handle missing devices
+if [ ${#MISSING_DEVICES[@]} -gt 0 ]; then
+    if [ ${#AVAILABLE_DEVICES[@]} -eq 0 ]; then
+        echo ""
+        echo "❌ No video devices available. Cannot proceed."
+        exit 1
+    fi
+    
+    echo ""
+    echo "⚠️  ${#MISSING_DEVICES[@]} device(s) not found."
+    echo "Available devices: ${AVAILABLE_DEVICES[*]}"
+    echo ""
+    echo -n "Continue with ${#AVAILABLE_DEVICES[@]} available device(s)? [y/N]: "
+    read continue_choice
+    if [[ ! "$continue_choice" =~ ^[Yy]$ ]]; then
+        echo "Aborting."
+        exit 1
+    fi
+fi
+
+NUM_CAMERAS=${#AVAILABLE_DEVICES[@]}
+echo ""
+echo "Recording with $NUM_CAMERAS camera(s)"
 
 # Request output directory with default
 default_output_dir="./recorded_videos"
@@ -48,7 +103,6 @@ mkdir -p "$output_dir"
 
 # Check disk space before starting recording
 echo "Checking disk space..."
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 python3 "$SCRIPT_DIR/disk_space_check.py" --path "$output_dir"
 if [ $? -ne 0 ]; then
     echo "❌ Disk space check failed. Please free up disk space and try again."
@@ -73,8 +127,18 @@ duration=180
 mkdir -p "$output_dir/$fin_name"
 cd "$output_dir/$fin_name"
 
+# Build device list for parallel execution
+DEVICE_LIST=""
+for i in "${!AVAILABLE_DEVICES[@]}"; do
+    if [ -n "$DEVICE_LIST" ]; then
+        DEVICE_LIST="$DEVICE_LIST\n$i:${AVAILABLE_DEVICES[$i]}"
+    else
+        DEVICE_LIST="$i:${AVAILABLE_DEVICES[$i]}"
+    fi
+done
+
 # Generate string to be evaluated using ffmpeg for video recording
-exec_string="seq 0 1 | parallel -j 2 ffmpeg -f v4l2 -i /dev/video{} -s 1280x720 -r 30 -c:v libx264 -preset ultrafast -crf 23 -pix_fmt yuv420p name_cam{}.mp4"
+exec_string="echo -e '$DEVICE_LIST' | parallel -j $NUM_CAMERAS --colsep ':' ffmpeg -f v4l2 -i {2} -s 1280x720 -r 30 -c:v libx264 -preset ultrafast -crf 23 -pix_fmt yuv420p name_cam{1}.mp4"
 
 time_file="name_markers.txt"
 time_file=${time_file/name/$fin_name}

--- a/parallel2video_streamer.sh
+++ b/parallel2video_streamer.sh
@@ -31,11 +31,66 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     echo "  - streamer"
     echo "  - GNU parallel"
     echo "  - figlet"
-    echo "  - Two video devices at /dev/video0 and /dev/video1"
+    echo "  - jq"
+    echo "  - Video devices configured in config.json"
     echo ""
     echo "Press Ctrl+C to stop recording."
     exit 0
 fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/config.json"
+
+# Check video devices from config
+echo "Checking video devices..."
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "❌ Config file not found: $CONFIG_FILE"
+    exit 1
+fi
+
+# Read video devices from config
+mapfile -t WANTED_DEVICES < <(jq -r '.video_devices[]' "$CONFIG_FILE" 2>/dev/null)
+if [ ${#WANTED_DEVICES[@]} -eq 0 ]; then
+    echo "❌ No video devices configured in config.json"
+    exit 1
+fi
+
+# Check which devices exist
+AVAILABLE_DEVICES=()
+MISSING_DEVICES=()
+for device in "${WANTED_DEVICES[@]}"; do
+    if [ -e "$device" ]; then
+        AVAILABLE_DEVICES+=("$device")
+        echo "✅ Found: $device"
+    else
+        MISSING_DEVICES+=("$device")
+        echo "❌ Missing: $device"
+    fi
+done
+
+# Handle missing devices
+if [ ${#MISSING_DEVICES[@]} -gt 0 ]; then
+    if [ ${#AVAILABLE_DEVICES[@]} -eq 0 ]; then
+        echo ""
+        echo "❌ No video devices available. Cannot proceed."
+        exit 1
+    fi
+    
+    echo ""
+    echo "⚠️  ${#MISSING_DEVICES[@]} device(s) not found."
+    echo "Available devices: ${AVAILABLE_DEVICES[*]}"
+    echo ""
+    echo -n "Continue with ${#AVAILABLE_DEVICES[@]} available device(s)? [y/N]: "
+    read continue_choice
+    if [[ ! "$continue_choice" =~ ^[Yy]$ ]]; then
+        echo "Aborting."
+        exit 1
+    fi
+fi
+
+NUM_CAMERAS=${#AVAILABLE_DEVICES[@]}
+echo ""
+echo "Recording with $NUM_CAMERAS camera(s)"
 
 # Request output directory with default
 default_output_dir="./recorded_videos"
@@ -48,7 +103,6 @@ mkdir -p "$output_dir"
 
 # Check disk space before starting recording
 echo "Checking disk space..."
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 python3 "$SCRIPT_DIR/disk_space_check.py" --path "$output_dir"
 if [ $? -ne 0 ]; then
     echo "❌ Disk space check failed. Please free up disk space and try again."
@@ -74,8 +128,18 @@ frames=$(expr 30 \* 60 \* $duration)
 mkdir -p "$output_dir/$fin_name"
 cd "$output_dir/$fin_name"
 
+# Build device list for parallel execution
+DEVICE_LIST=""
+for i in "${!AVAILABLE_DEVICES[@]}"; do
+    if [ -n "$DEVICE_LIST" ]; then
+        DEVICE_LIST="$DEVICE_LIST\n$i:${AVAILABLE_DEVICES[$i]}"
+    else
+        DEVICE_LIST="$i:${AVAILABLE_DEVICES[$i]}"
+    fi
+done
+
 # Generate string to be evaluated
-exec_string="seq 0 1 | parallel -j 2 streamer -q -c /dev/video{} -s 1280x720 -f jpeg -t frames -r 30 -j 75 -w 0 -o name_cam{}.avi"
+exec_string="echo -e '$DEVICE_LIST' | parallel -j $NUM_CAMERAS --colsep ':' streamer -q -c {2} -s 1280x720 -f jpeg -t frames -r 30 -j 75 -w 0 -o name_cam{1}.avi"
 
 time_file="name_markers.txt"
 time_file=${time_file/name/$fin_name}

--- a/test_parallel_scripts.py
+++ b/test_parallel_scripts.py
@@ -48,13 +48,13 @@ def test_ffmpeg_command_structure():
     # Check for key ffmpeg components
     assert "ffmpeg" in content, "Script should contain ffmpeg command"
     assert "-f v4l2" in content, "Script should use v4l2 format for Linux cameras"
-    assert "-i /dev/video{}" in content, "Script should reference video devices"
+    assert "-i {2}" in content, "Script should reference video devices dynamically"
     assert "-s 1280x720" in content, "Script should set video resolution"
     assert "-r 30" in content, "Script should set frame rate"
     assert "libx264" in content, "Script should use H.264 encoding"
     assert "-preset ultrafast" in content, "Script should use ultrafast preset for low latency"
     assert "-crf 23" in content, "Script should set quality level"
-    assert "parallel -j 2" in content, "Script should use parallel for simultaneous recording"
+    assert "parallel -j $NUM_CAMERAS" in content, "Script should use parallel with dynamic camera count"
     
     print("✓ FFmpeg command structure tests passed")
 
@@ -67,11 +67,11 @@ def test_streamer_command_structure():
     
     # Check for key streamer components
     assert "streamer" in content, "Script should contain streamer command"
-    assert "-c /dev/video{}" in content, "Script should reference video devices"
+    assert "-c {2}" in content, "Script should reference video devices dynamically"
     assert "-s 1280x720" in content, "Script should set video resolution"
     assert "-f jpeg" in content, "Script should use jpeg format"
     assert "-r 30" in content, "Script should set frame rate"
-    assert "parallel -j 2" in content, "Script should use parallel for simultaneous recording"
+    assert "parallel -j $NUM_CAMERAS" in content, "Script should use parallel with dynamic camera count"
     assert ".avi" in content, "Script should output AVI files"
     
     print("✓ Streamer command structure tests passed")
@@ -87,8 +87,8 @@ def test_directory_structure_creation():
             content = f.read()
         
         # Check for directory creation
-        assert "mkdir $fin_name" in content, f"{script} should create directory with final name"
-        assert "cd $fin_name" in content, f"{script} should change to created directory"
+        assert 'mkdir -p "$output_dir/$fin_name"' in content, f"{script} should create directory with final name"
+        assert 'cd "$output_dir/$fin_name"' in content, f"{script} should change to created directory"
         
         # Check for marker file creation
         assert "markers.txt" in content, f"{script} should create marker file"
@@ -97,6 +97,49 @@ def test_directory_structure_creation():
         assert "date +%s.%N" in content, f"{script} should record timestamps"
     
     print("✓ Directory structure creation tests passed")
+
+def test_device_checking():
+    """Test that scripts check for video devices from config"""
+    print("Testing device checking functionality...")
+    
+    scripts = ["parallel2video_ffmpeg.sh", "parallel2video_streamer.sh"]
+    
+    for script in scripts:
+        with open(script, "r") as f:
+            content = f.read()
+        
+        # Check for config file reading
+        assert "config.json" in content, f"{script} should read from config.json"
+        assert "jq" in content, f"{script} should use jq to parse config"
+        assert "video_devices" in content, f"{script} should read video_devices from config"
+        
+        # Check for device existence checking
+        assert "AVAILABLE_DEVICES" in content, f"{script} should track available devices"
+        assert "MISSING_DEVICES" in content, f"{script} should track missing devices"
+        assert '[ -e "$device" ]' in content, f"{script} should check if device exists"
+        
+        # Check for user prompt on missing devices
+        assert "Continue with" in content, f"{script} should prompt user to continue"
+        assert "Aborting" in content, f"{script} should allow user to abort"
+    
+    print("✓ Device checking tests passed")
+
+def test_config_has_video_devices():
+    """Test that config.json has video_devices array"""
+    print("Testing config.json video_devices...")
+    
+    import json
+    with open("config.json", "r") as f:
+        config = json.load(f)
+    
+    assert "video_devices" in config, "config.json should have video_devices"
+    assert isinstance(config["video_devices"], list), "video_devices should be a list"
+    assert len(config["video_devices"]) > 0, "video_devices should not be empty"
+    
+    for device in config["video_devices"]:
+        assert device.startswith("/dev/video"), f"Device {device} should be a /dev/video path"
+    
+    print("✓ Config video_devices tests passed")
 
 def test_script_differences():
     """Test that ffmpeg and streamer scripts have key differences"""
@@ -152,6 +195,8 @@ def main():
         test_ffmpeg_command_structure()
         test_streamer_command_structure()
         test_directory_structure_creation()
+        test_device_checking()
+        test_config_has_video_devices()
         test_script_differences()
         test_readme_updated()
         


### PR DESCRIPTION
## Summary

Addresses #42 - adds configurable video devices to config and validates device existence before recording.

## Changes

- **config.json**: Added `video_devices` array to specify wanted devices
- **parallel2video_ffmpeg.sh**: Added device checking logic with user prompt
- **parallel2video_streamer.sh**: Added device checking logic with user prompt  
- **test_parallel_scripts.py**: Updated tests for new functionality

## Behavior

1. Scripts read device list from `config.json`
2. Check each device exists before recording
3. If devices missing:
   - Show which devices are available/missing
   - Prompt user to continue with available devices or abort
4. Parallel job count adjusts to number of confirmed devices

## New dependency

Scripts now require `jq` for JSON parsing.