### PR TITLE
Extract shared setup code into recording_utils.sh

### DIFF
--- a/parallel2video_ffmpeg.sh
+++ b/parallel2video_ffmpeg.sh
@@ -8,150 +8,43 @@ Outputs:
 -Marker text file (start and stop times for recording)
 '
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/recording_utils.sh"
+
 # Help flag
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
-    echo "Usage: $(basename "$0") [OPTIONS]"
-    echo ""
-    echo "Record video from 2 cameras simultaneously using ffmpeg."
-    echo ""
-    echo "Options:"
-    echo "  -h, --help    Show this help message and exit"
-    echo ""
-    echo "Inputs (prompted interactively):"
-    echo "  output_dir    Directory to save recordings (default: ./recorded_videos)"
-    echo "  name          Base name for output files"
-    echo ""
-    echo "Outputs:"
-    echo "  <output_dir>/<name>_video_<timestamp>/           Directory containing all outputs"
-    echo "  <output_dir>/<name>_video_<timestamp>_cam0.mp4   Video from camera 0 (H.264, 1280x720, 30fps)"
-    echo "  <output_dir>/<name>_video_<timestamp>_cam1.mp4   Video from camera 1 (H.264, 1280x720, 30fps)"
-    echo "  <output_dir>/<name>_video_<timestamp>_markers.txt  Start/stop timestamps (Unix epoch)"
-    echo ""
-    echo "Requirements:"
-    echo "  - ffmpeg"
-    echo "  - GNU parallel"
-    echo "  - figlet"
-    echo "  - jq"
-    echo "  - Video devices configured in config.json"
-    echo ""
-    echo "Press Ctrl+C to stop recording."
+    show_help "$0" "ffmpeg" "H.264" "mp4"
     exit 0
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CONFIG_FILE="$SCRIPT_DIR/config.json"
+# Load video devices from config
+load_video_devices "$SCRIPT_DIR" || exit 1
 
-# Check video devices from config
-echo "Checking video devices..."
-if [ ! -f "$CONFIG_FILE" ]; then
-    echo "❌ Config file not found: $CONFIG_FILE"
-    exit 1
-fi
+# Setup output directory with disk space check
+setup_output_directory "$SCRIPT_DIR" || exit 1
 
-# Read video devices from config
-mapfile -t WANTED_DEVICES < <(jq -r '.video_devices[]' "$CONFIG_FILE" 2>/dev/null)
-if [ ${#WANTED_DEVICES[@]} -eq 0 ]; then
-    echo "❌ No video devices configured in config.json"
-    exit 1
-fi
-
-# Check which devices exist
-AVAILABLE_DEVICES=()
-MISSING_DEVICES=()
-for device in "${WANTED_DEVICES[@]}"; do
-    if [ -e "$device" ]; then
-        AVAILABLE_DEVICES+=("$device")
-        echo "✅ Found: $device"
-    else
-        MISSING_DEVICES+=("$device")
-        echo "❌ Missing: $device"
-    fi
-done
-
-# Handle missing devices
-if [ ${#MISSING_DEVICES[@]} -gt 0 ]; then
-    if [ ${#AVAILABLE_DEVICES[@]} -eq 0 ]; then
-        echo ""
-        echo "❌ No video devices available. Cannot proceed."
-        exit 1
-    fi
-    
-    echo ""
-    echo "⚠️  ${#MISSING_DEVICES[@]} device(s) not found."
-    echo "Available devices: ${AVAILABLE_DEVICES[*]}"
-    echo ""
-    echo -n "Continue with ${#AVAILABLE_DEVICES[@]} available device(s)? [y/N]: "
-    read continue_choice
-    if [[ ! "$continue_choice" =~ ^[Yy]$ ]]; then
-        echo "Aborting."
-        exit 1
-    fi
-fi
-
-NUM_CAMERAS=${#AVAILABLE_DEVICES[@]}
-echo ""
-echo "Recording with $NUM_CAMERAS camera(s)"
-
-# Request output directory with default
-default_output_dir="./recorded_videos"
-echo -n "Enter output directory [$default_output_dir]: "
-read output_dir
-output_dir=${output_dir:-$default_output_dir}
-
-# Create output directory if it doesn't exist
-mkdir -p "$output_dir"
-
-# Check disk space before starting recording
-echo "Checking disk space..."
-python3 "$SCRIPT_DIR/disk_space_check.py" --path "$output_dir"
-if [ $? -ne 0 ]; then
-    echo "❌ Disk space check failed. Please free up disk space and try again."
-    exit 1
-fi
-
-# Initialize name template
-name_template=name_video_time
-# Request name and collect time
-echo -n "Enter name: "
-read name
-time=$(date +%g%m%d-%H%M%S)
-# Generate final name using input name and time
-fin_name=${name_template/name/$name}
-fin_name=${fin_name/time/$time}
-echo "File name : $fin_name"
+# Generate recording name
+generate_recording_name
 
 # Duration set to very large number, script is killed to stop recording
 duration=180
 
-# Make directory to store everything using final name inside output directory
-mkdir -p "$output_dir/$fin_name"
-cd "$output_dir/$fin_name"
+# Setup recording directory
+setup_recording_directory "$output_dir" "$fin_name"
 
 # Build device list for parallel execution
-DEVICE_LIST=""
-for i in "${!AVAILABLE_DEVICES[@]}"; do
-    if [ -n "$DEVICE_LIST" ]; then
-        DEVICE_LIST="$DEVICE_LIST\n$i:${AVAILABLE_DEVICES[$i]}"
-    else
-        DEVICE_LIST="$i:${AVAILABLE_DEVICES[$i]}"
-    fi
-done
+build_device_list
 
 # Generate string to be evaluated using ffmpeg for video recording
-exec_string="echo -e '$DEVICE_LIST' | parallel -j $NUM_CAMERAS --colsep ':' ffmpeg -f v4l2 -i {2} -s 1280x720 -r 30 -c:v libx264 -preset ultrafast -crf 23 -pix_fmt yuv420p name_cam{1}.mp4"
+exec_string="echo -e '$DEVICE_LIST' | parallel -j $NUM_CAMERAS --colsep ':' ffmpeg -f v4l2 -i {2} -s 1280x720 -r 30 -c:v libx264 -preset ultrafast -crf 23 -pix_fmt yuv420p ${fin_name}_cam{1}.mp4"
 
-time_file="name_markers.txt"
-time_file=${time_file/name/$fin_name}
-exec_string=${exec_string/name/$fin_name}
+time_file="${fin_name}_markers.txt"
 
-figlet "ctrl+c to stop"
+# Start recording with marker
+start_recording "$time_file"
 
-# Write start and stop time and execute video recording
-echo "Start time : $(date)"
-echo
-
-date +%s.%N | cut -b-14 > $time_file
+# Execute video recording
 eval $exec_string
-echo "Stop time : $(date)"
-echo
-date +%s.%N | cut -b-14 >> $time_file
+
+# Stop recording with marker
+stop_recording "$time_file"

--- a/parallel2video_streamer.sh
+++ b/parallel2video_streamer.sh
@@ -1,159 +1,51 @@
 #!/bin/bash
 
 : '
-Script to simulatenously record from 2 cameras
+Script to simultaneously record from 2 cameras
 When run requests input for filename and time in minutes
 Outputs:
 -Video files
 -Marker text file (start and stop times for recording)
 '
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/recording_utils.sh"
+
 # Help flag
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
-    echo "Usage: $(basename "$0") [OPTIONS]"
-    echo ""
-    echo "Record video from 2 cameras simultaneously using streamer."
-    echo ""
-    echo "Options:"
-    echo "  -h, --help    Show this help message and exit"
-    echo ""
-    echo "Inputs (prompted interactively):"
-    echo "  output_dir    Directory to save recordings (default: ./recorded_videos)"
-    echo "  name          Base name for output files"
-    echo ""
-    echo "Outputs:"
-    echo "  <output_dir>/<name>_video_<timestamp>/           Directory containing all outputs"
-    echo "  <output_dir>/<name>_video_<timestamp>_cam0.avi   Video from camera 0 (JPEG, 1280x720, 30fps)"
-    echo "  <output_dir>/<name>_video_<timestamp>_cam1.avi   Video from camera 1 (JPEG, 1280x720, 30fps)"
-    echo "  <output_dir>/<name>_video_<timestamp>_markers.txt  Start/stop timestamps (Unix epoch)"
-    echo ""
-    echo "Requirements:"
-    echo "  - streamer"
-    echo "  - GNU parallel"
-    echo "  - figlet"
-    echo "  - jq"
-    echo "  - Video devices configured in config.json"
-    echo ""
-    echo "Press Ctrl+C to stop recording."
+    show_help "$0" "streamer" "JPEG" "avi"
     exit 0
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CONFIG_FILE="$SCRIPT_DIR/config.json"
+# Load video devices from config
+load_video_devices "$SCRIPT_DIR" || exit 1
 
-# Check video devices from config
-echo "Checking video devices..."
-if [ ! -f "$CONFIG_FILE" ]; then
-    echo "❌ Config file not found: $CONFIG_FILE"
-    exit 1
-fi
+# Setup output directory with disk space check
+setup_output_directory "$SCRIPT_DIR" || exit 1
 
-# Read video devices from config
-mapfile -t WANTED_DEVICES < <(jq -r '.video_devices[]' "$CONFIG_FILE" 2>/dev/null)
-if [ ${#WANTED_DEVICES[@]} -eq 0 ]; then
-    echo "❌ No video devices configured in config.json"
-    exit 1
-fi
-
-# Check which devices exist
-AVAILABLE_DEVICES=()
-MISSING_DEVICES=()
-for device in "${WANTED_DEVICES[@]}"; do
-    if [ -e "$device" ]; then
-        AVAILABLE_DEVICES+=("$device")
-        echo "✅ Found: $device"
-    else
-        MISSING_DEVICES+=("$device")
-        echo "❌ Missing: $device"
-    fi
-done
-
-# Handle missing devices
-if [ ${#MISSING_DEVICES[@]} -gt 0 ]; then
-    if [ ${#AVAILABLE_DEVICES[@]} -eq 0 ]; then
-        echo ""
-        echo "❌ No video devices available. Cannot proceed."
-        exit 1
-    fi
-    
-    echo ""
-    echo "⚠️  ${#MISSING_DEVICES[@]} device(s) not found."
-    echo "Available devices: ${AVAILABLE_DEVICES[*]}"
-    echo ""
-    echo -n "Continue with ${#AVAILABLE_DEVICES[@]} available device(s)? [y/N]: "
-    read continue_choice
-    if [[ ! "$continue_choice" =~ ^[Yy]$ ]]; then
-        echo "Aborting."
-        exit 1
-    fi
-fi
-
-NUM_CAMERAS=${#AVAILABLE_DEVICES[@]}
-echo ""
-echo "Recording with $NUM_CAMERAS camera(s)"
-
-# Request output directory with default
-default_output_dir="./recorded_videos"
-echo -n "Enter output directory [$default_output_dir]: "
-read output_dir
-output_dir=${output_dir:-$default_output_dir}
-
-# Create output directory if it doesn't exist
-mkdir -p "$output_dir"
-
-# Check disk space before starting recording
-echo "Checking disk space..."
-python3 "$SCRIPT_DIR/disk_space_check.py" --path "$output_dir"
-if [ $? -ne 0 ]; then
-    echo "❌ Disk space check failed. Please free up disk space and try again."
-    exit 1
-fi
-
-# Initialize name template
-name_template=name_video_time
-# Request name and collect time
-echo -n "Enter name: "
-read name
-time=$(date +%g%m%d-%H%M%S)
-# Generate final name using input name and time
-fin_name=${name_template/name/$name}
-fin_name=${fin_name/time/$time}
-echo "File name : $fin_name"
+# Generate recording name
+generate_recording_name
 
 # Duration set to very large number, script is killed to stop recording
 duration=180
 frames=$(expr 30 \* 60 \* $duration)
 
-# Make directory to store everything using final name inside output directory
-mkdir -p "$output_dir/$fin_name"
-cd "$output_dir/$fin_name"
+# Setup recording directory
+setup_recording_directory "$output_dir" "$fin_name"
 
 # Build device list for parallel execution
-DEVICE_LIST=""
-for i in "${!AVAILABLE_DEVICES[@]}"; do
-    if [ -n "$DEVICE_LIST" ]; then
-        DEVICE_LIST="$DEVICE_LIST\n$i:${AVAILABLE_DEVICES[$i]}"
-    else
-        DEVICE_LIST="$i:${AVAILABLE_DEVICES[$i]}"
-    fi
-done
+build_device_list
 
-# Generate string to be evaluated
-exec_string="echo -e '$DEVICE_LIST' | parallel -j $NUM_CAMERAS --colsep ':' streamer -q -c {2} -s 1280x720 -f jpeg -t frames -r 30 -j 75 -w 0 -o name_cam{1}.avi"
+# Generate string to be evaluated using streamer for video recording
+exec_string="echo -e '$DEVICE_LIST' | parallel -j $NUM_CAMERAS --colsep ':' streamer -q -c {2} -s 1280x720 -f jpeg -t $frames -r 30 -j 75 -w 0 -o ${fin_name}_cam{1}.avi"
 
-time_file="name_markers.txt"
-time_file=${time_file/name/$fin_name}
-exec_string=${exec_string/name/$fin_name}
-exec_string=${exec_string/frames/$frames}
+time_file="${fin_name}_markers.txt"
 
-figlet "ctrl+c to stop"
+# Start recording with marker
+start_recording "$time_file"
 
-# Write start and stop time and execute video recording
-echo "Start time : $(date)"
-echo
-
-date +%s.%N | cut -b-14 > $time_file
+# Execute video recording
 eval $exec_string
-echo "Stop time : $(date)"
-echo
-date +%s.%N | cut -b-14 >> $time_file
+
+# Stop recording with marker
+stop_recording "$time_file"

--- a/recording_utils.sh
+++ b/recording_utils.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+# Shared utility functions for multicam recording scripts
+
+# Get script directory (call from sourcing script)
+get_script_dir() {
+    cd "$(dirname "${BASH_SOURCE[1]}")" && pwd
+}
+
+# Show help message
+# Args: $1 = script name, $2 = tool name, $3 = video format, $4 = video extension
+show_help() {
+    local script_name="$1"
+    local tool_name="$2"
+    local video_format="$3"
+    local video_ext="$4"
+    
+    echo "Usage: $(basename "$script_name") [OPTIONS]"
+    echo ""
+    echo "Record video from 2 cameras simultaneously using $tool_name."
+    echo ""
+    echo "Options:"
+    echo "  -h, --help    Show this help message and exit"
+    echo ""
+    echo "Inputs (prompted interactively):"
+    echo "  output_dir    Directory to save recordings (default: ./recorded_videos)"
+    echo "  name          Base name for output files"
+    echo ""
+    echo "Outputs:"
+    echo "  <output_dir>/<name>_video_<timestamp>/           Directory containing all outputs"
+    echo "  <output_dir>/<name>_video_<timestamp>_cam0.$video_ext   Video from camera 0 ($video_format, 1280x720, 30fps)"
+    echo "  <output_dir>/<name>_video_<timestamp>_cam1.$video_ext   Video from camera 1 ($video_format, 1280x720, 30fps)"
+    echo "  <output_dir>/<name>_video_<timestamp>_markers.txt  Start/stop timestamps (Unix epoch)"
+    echo ""
+    echo "Requirements:"
+    echo "  - $tool_name"
+    echo "  - GNU parallel"
+    echo "  - figlet"
+    echo "  - jq"
+    echo "  - Video devices configured in config.json"
+    echo ""
+    echo "Press Ctrl+C to stop recording."
+}
+
+# Load and validate video devices from config
+# Sets: AVAILABLE_DEVICES array, NUM_CAMERAS
+# Returns: 0 on success, 1 on failure
+load_video_devices() {
+    local script_dir="$1"
+    local config_file="$script_dir/config.json"
+    
+    echo "Checking video devices..."
+    if [ ! -f "$config_file" ]; then
+        echo "❌ Config file not found: $config_file"
+        return 1
+    fi
+
+    # Read video devices from config
+    local wanted_devices
+    mapfile -t wanted_devices < <(jq -r '.video_devices[]' "$config_file" 2>/dev/null)
+    if [ ${#wanted_devices[@]} -eq 0 ]; then
+        echo "❌ No video devices configured in config.json"
+        return 1
+    fi
+
+    # Check which devices exist
+    AVAILABLE_DEVICES=()
+    local missing_devices=()
+    for device in "${wanted_devices[@]}"; do
+        if [ -e "$device" ]; then
+            AVAILABLE_DEVICES+=("$device")
+            echo "✅ Found: $device"
+        else
+            missing_devices+=("$device")
+            echo "❌ Missing: $device"
+        fi
+    done
+
+    # Handle missing devices
+    if [ ${#missing_devices[@]} -gt 0 ]; then
+        if [ ${#AVAILABLE_DEVICES[@]} -eq 0 ]; then
+            echo ""
+            echo "❌ No video devices available. Cannot proceed."
+            return 1
+        fi
+        
+        echo ""
+        echo "⚠️  ${#missing_devices[@]} device(s) not found."
+        echo "Available devices: ${AVAILABLE_DEVICES[*]}"
+        echo ""
+        echo -n "Continue with ${#AVAILABLE_DEVICES[@]} available device(s)? [y/N]: "
+        read continue_choice
+        if [[ ! "$continue_choice" =~ ^[Yy]$ ]]; then
+            echo "Aborting."
+            return 1
+        fi
+    fi
+
+    NUM_CAMERAS=${#AVAILABLE_DEVICES[@]}
+    echo ""
+    echo "Recording with $NUM_CAMERAS camera(s)"
+    return 0
+}
+
+# Setup output directory with disk space check
+# Args: $1 = script_dir
+# Sets: output_dir
+# Returns: 0 on success, 1 on failure
+setup_output_directory() {
+    local script_dir="$1"
+    local default_output_dir="./recorded_videos"
+    
+    echo -n "Enter output directory [$default_output_dir]: "
+    read output_dir
+    output_dir=${output_dir:-$default_output_dir}
+
+    # Create output directory if it doesn't exist
+    mkdir -p "$output_dir"
+
+    # Check disk space before starting recording
+    echo "Checking disk space..."
+    python3 "$script_dir/disk_space_check.py" --path "$output_dir"
+    if [ $? -ne 0 ]; then
+        echo "❌ Disk space check failed. Please free up disk space and try again."
+        return 1
+    fi
+    return 0
+}
+
+# Generate recording name with timestamp
+# Sets: fin_name
+generate_recording_name() {
+    local name_template="name_video_time"
+    
+    echo -n "Enter name: "
+    read name
+    local time=$(date +%g%m%d-%H%M%S)
+    
+    fin_name=${name_template/name/$name}
+    fin_name=${fin_name/time/$time}
+    echo "File name : $fin_name"
+}
+
+# Build device list string for parallel execution
+# Uses: AVAILABLE_DEVICES array
+# Sets: DEVICE_LIST
+build_device_list() {
+    DEVICE_LIST=""
+    for i in "${!AVAILABLE_DEVICES[@]}"; do
+        if [ -n "$DEVICE_LIST" ]; then
+            DEVICE_LIST="$DEVICE_LIST\n$i:${AVAILABLE_DEVICES[$i]}"
+        else
+            DEVICE_LIST="$i:${AVAILABLE_DEVICES[$i]}"
+        fi
+    done
+}
+
+# Create recording directory and change to it
+# Args: $1 = output_dir, $2 = fin_name
+setup_recording_directory() {
+    local output_dir="$1"
+    local fin_name="$2"
+    
+    mkdir -p "$output_dir/$fin_name"
+    cd "$output_dir/$fin_name"
+}
+
+# Write start marker and show recording message
+# Args: $1 = time_file
+start_recording() {
+    local time_file="$1"
+    
+    figlet "ctrl+c to stop"
+    echo "Start time : $(date)"
+    echo
+    date +%s.%N | cut -b-14 > "$time_file"
+}
+
+# Write stop marker
+# Args: $1 = time_file
+stop_recording() {
+    local time_file="$1"
+    
+    echo "Stop time : $(date)"
+    echo
+    date +%s.%N | cut -b-14 >> "$time_file"
+}

--- a/test_parallel_scripts.py
+++ b/test_parallel_scripts.py
@@ -24,13 +24,18 @@ def test_script_exists():
     assert streamer_script.exists(), "parallel2video_streamer.sh should exist"
     assert os.access(streamer_script, os.X_OK), "parallel2video_streamer.sh should be executable"
     
+    # Test utils script
+    utils_script = Path("recording_utils.sh")
+    assert utils_script.exists(), "recording_utils.sh should exist"
+    assert os.access(utils_script, os.X_OK), "recording_utils.sh should be executable"
+    
     print("✓ Script existence and executability tests passed")
 
 def test_script_syntax():
     """Test that scripts have valid bash syntax"""
     print("Testing script syntax...")
     
-    scripts = ["parallel2video_ffmpeg.sh", "parallel2video_streamer.sh"]
+    scripts = ["parallel2video_ffmpeg.sh", "parallel2video_streamer.sh", "recording_utils.sh"]
     
     for script in scripts:
         result = subprocess.run(["bash", "-n", script], capture_output=True, text=True)
@@ -82,19 +87,27 @@ def test_directory_structure_creation():
     
     scripts = ["parallel2video_ffmpeg.sh", "parallel2video_streamer.sh"]
     
+    # Read utils file for shared functionality
+    with open("recording_utils.sh", "r") as f:
+        utils_content = f.read()
+    
+    # Check for directory creation in utils
+    assert 'mkdir -p "$output_dir/$fin_name"' in utils_content, "Utils should create directory with final name"
+    assert 'cd "$output_dir/$fin_name"' in utils_content, "Utils should change to created directory"
+    
+    # Check for timing functionality in utils
+    assert "date +%s.%N" in utils_content, "Utils should record timestamps"
+    
     for script in scripts:
         with open(script, "r") as f:
             content = f.read()
         
-        # Check for directory creation
-        assert 'mkdir -p "$output_dir/$fin_name"' in content, f"{script} should create directory with final name"
-        assert 'cd "$output_dir/$fin_name"' in content, f"{script} should change to created directory"
+        # Check that scripts source utils and use shared functions
+        assert "source" in content and "recording_utils.sh" in content, f"{script} should source recording_utils.sh"
+        assert "setup_recording_directory" in content, f"{script} should use setup_recording_directory function"
         
         # Check for marker file creation
         assert "markers.txt" in content, f"{script} should create marker file"
-        
-        # Check for timing functionality
-        assert "date +%s.%N" in content, f"{script} should record timestamps"
     
     print("✓ Directory structure creation tests passed")
 
@@ -102,25 +115,33 @@ def test_device_checking():
     """Test that scripts check for video devices from config"""
     print("Testing device checking functionality...")
     
+    # Read utils file for shared functionality
+    with open("recording_utils.sh", "r") as f:
+        utils_content = f.read()
+    
+    # Check for config file reading in utils
+    assert "config.json" in utils_content, "Utils should read from config.json"
+    assert "jq" in utils_content, "Utils should use jq to parse config"
+    assert "video_devices" in utils_content, "Utils should read video_devices from config"
+    
+    # Check for device existence checking in utils
+    assert "AVAILABLE_DEVICES" in utils_content, "Utils should track available devices"
+    assert "missing_devices" in utils_content, "Utils should track missing devices"
+    assert '[ -e "$device" ]' in utils_content, "Utils should check if device exists"
+    
+    # Check for user prompt on missing devices in utils
+    assert "Continue with" in utils_content, "Utils should prompt user to continue"
+    assert "Aborting" in utils_content, "Utils should allow user to abort"
+    
     scripts = ["parallel2video_ffmpeg.sh", "parallel2video_streamer.sh"]
     
     for script in scripts:
         with open(script, "r") as f:
             content = f.read()
         
-        # Check for config file reading
-        assert "config.json" in content, f"{script} should read from config.json"
-        assert "jq" in content, f"{script} should use jq to parse config"
-        assert "video_devices" in content, f"{script} should read video_devices from config"
-        
-        # Check for device existence checking
-        assert "AVAILABLE_DEVICES" in content, f"{script} should track available devices"
-        assert "MISSING_DEVICES" in content, f"{script} should track missing devices"
-        assert '[ -e "$device" ]' in content, f"{script} should check if device exists"
-        
-        # Check for user prompt on missing devices
-        assert "Continue with" in content, f"{script} should prompt user to continue"
-        assert "Aborting" in content, f"{script} should allow user to abort"
+        # Check that scripts source utils and use shared functions
+        assert "source" in content and "recording_utils.sh" in content, f"{script} should source recording_utils.sh"
+        assert "load_video_devices" in content, f"{script} should use load_video_devices function"
     
     print("✓ Device checking tests passed")
 


### PR DESCRIPTION
Addresses #44 - share setup code between ffmpeg and streamer scripts.

## Changes

Creates `recording_utils.sh` with shared functions:
- `load_video_devices()` - config loading and device validation
- `setup_output_directory()` - directory creation with disk space check
- `generate_recording_name()` - timestamp-based naming
- `setup_recording_directory()` - recording folder creation
- `build_device_list()` - parallel execution setup
- `start_recording()` / `stop_recording()` - marker file handling
- `show_help()` - parameterized help output

Both `parallel2video_ffmpeg.sh` and `parallel2video_streamer.sh` now source the utils and call these functions, reducing duplication from ~150 lines each to ~50 lines.

## Testing

- All 20 tests pass
- Help output verified for both scripts
- Bash syntax validation passes