### PR TITLE
Add ramdisk support for disk I/O limited recording

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,5 +14,10 @@
   "video_devices": [
     "/dev/video0",
     "/dev/video1"
-  ]
+  ],
+  "ramdisk": {
+    "enabled": false,
+    "path": "/tmp/multicam_ramdisk",
+    "size_gb": 4
+  }
 }

--- a/parallel2video_ffmpeg.sh
+++ b/parallel2video_ffmpeg.sh
@@ -14,6 +14,7 @@ Options:
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/recording_utils.sh"
+source "$SCRIPT_DIR/ramdisk_utils.sh"
 
 # Function to handle Ctrl+C - ensures timestamps are extracted before exit
 cleanup_on_interrupt() {
@@ -37,6 +38,15 @@ cleanup_on_interrupt() {
             echo "Timestamps saved to ${timestamps_file}" 
         fi
     done
+    
+    # Move files from ramdisk to final destination if ramdisk was used
+    if [ "$RAMDISK_ACTIVE" -eq 1 ] && [ -n "$FINAL_OUTPUT_DIR" ]; then
+        move_from_ramdisk "$(pwd)" "$FINAL_OUTPUT_DIR"
+        cd "$FINAL_OUTPUT_DIR"
+    fi
+    
+    # Cleanup ramdisk
+    cleanup_ramdisk "$SCRIPT_DIR"
     
     echo "Recording and timestamp extraction complete!" >&2
     exit 0
@@ -63,8 +73,23 @@ generate_recording_name
 # Duration set to very large number, script is killed to stop recording
 duration=180
 
-# Setup recording directory
-setup_recording_directory "$output_dir" "$fin_name"
+# Setup ramdisk if enabled
+setup_ramdisk "$SCRIPT_DIR"
+FINAL_OUTPUT_DIR="$output_dir/$fin_name"
+
+# Get recording path (ramdisk or disk)
+recording_path=$(get_recording_path "$output_dir" "$fin_name")
+
+# Setup recording directory (use ramdisk path if available)
+mkdir -p "$recording_path"
+cd "$recording_path"
+
+if [ "$RAMDISK_ACTIVE" -eq 1 ]; then
+    echo "Recording to ramdisk: $recording_path"
+    echo "Final destination: $FINAL_OUTPUT_DIR"
+else
+    echo "Recording to disk: $recording_path"
+fi
 
 # Build device list for parallel execution
 build_device_list
@@ -98,9 +123,24 @@ trap - SIGINT
 stop_recording "$time_file"
 
 # Extract timestamps from recorded video files
-# If not interrupted, extract timestamps here
-if [ $? -eq 0 ]; then
-    cleanup_on_interrupt
+echo "Extracting timestamps from video files..."
+for i in $(seq 0 $((NUM_CAMERAS - 1))); do
+    video_file="name_cam${i}.mp4"
+    timestamps_file="cam${i}_timestamps.txt"
+    if [ -f $video_file ]; then
+        echo "Extracting timestamps from ${video_file}..." 
+        ffmpeg -i $video_file -f mkvtimestamp_v2 -copyts $timestamps_file 2>/dev/null
+        echo "Timestamps saved to ${timestamps_file}" 
+    fi
+done
+
+# Move files from ramdisk to final destination if ramdisk was used
+if [ "$RAMDISK_ACTIVE" -eq 1 ] && [ -n "$FINAL_OUTPUT_DIR" ]; then
+    move_from_ramdisk "$(pwd)" "$FINAL_OUTPUT_DIR"
+    cd "$FINAL_OUTPUT_DIR"
 fi
+
+# Cleanup ramdisk
+cleanup_ramdisk "$SCRIPT_DIR"
 
 echo "Recording and timestamp extraction complete!"

--- a/parallel2video_streamer.sh
+++ b/parallel2video_streamer.sh
@@ -10,6 +10,7 @@ Outputs:
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/recording_utils.sh"
+source "$SCRIPT_DIR/ramdisk_utils.sh"
 
 # Help flag
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
@@ -30,8 +31,23 @@ generate_recording_name
 duration=180
 frames=$(expr 30 \* 60 \* $duration)
 
-# Setup recording directory
-setup_recording_directory "$output_dir" "$fin_name"
+# Setup ramdisk if enabled
+setup_ramdisk "$SCRIPT_DIR"
+FINAL_OUTPUT_DIR="$output_dir/$fin_name"
+
+# Get recording path (ramdisk or disk)
+recording_path=$(get_recording_path "$output_dir" "$fin_name")
+
+# Setup recording directory (use ramdisk path if available)
+mkdir -p "$recording_path"
+cd "$recording_path"
+
+if [ "$RAMDISK_ACTIVE" -eq 1 ]; then
+    echo "Recording to ramdisk: $recording_path"
+    echo "Final destination: $FINAL_OUTPUT_DIR"
+else
+    echo "Recording to disk: $recording_path"
+fi
 
 # Build device list for parallel execution
 build_device_list
@@ -49,3 +65,14 @@ eval $exec_string
 
 # Stop recording with marker
 stop_recording "$time_file"
+
+# Move files from ramdisk to final destination if ramdisk was used
+if [ "$RAMDISK_ACTIVE" -eq 1 ] && [ -n "$FINAL_OUTPUT_DIR" ]; then
+    move_from_ramdisk "$(pwd)" "$FINAL_OUTPUT_DIR"
+    cd "$FINAL_OUTPUT_DIR"
+fi
+
+# Cleanup ramdisk
+cleanup_ramdisk "$SCRIPT_DIR"
+
+echo "Recording complete!"

--- a/ramdisk_utils.sh
+++ b/ramdisk_utils.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+
+# Ramdisk utility functions for multicam recording
+# Provides functions to use tmpfs/ramdisk for recording when disk I/O is limited
+
+# Default ramdisk mount point
+DEFAULT_RAMDISK_PATH="/tmp/multicam_ramdisk"
+
+# Check if ramdisk is enabled in config
+# Args: $1 = script_dir
+# Returns: 0 if enabled, 1 if disabled
+is_ramdisk_enabled() {
+    local script_dir="$1"
+    local config_file="$script_dir/config.json"
+    
+    if [ ! -f "$config_file" ]; then
+        return 1
+    fi
+    
+    local enabled
+    enabled=$(jq -r '.ramdisk.enabled // false' "$config_file" 2>/dev/null)
+    
+    if [ "$enabled" = "true" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Get ramdisk configuration
+# Args: $1 = script_dir
+# Sets: RAMDISK_PATH, RAMDISK_SIZE_GB
+get_ramdisk_config() {
+    local script_dir="$1"
+    local config_file="$script_dir/config.json"
+    
+    RAMDISK_PATH=$(jq -r '.ramdisk.path // "/tmp/multicam_ramdisk"' "$config_file" 2>/dev/null)
+    RAMDISK_SIZE_GB=$(jq -r '.ramdisk.size_gb // 4' "$config_file" 2>/dev/null)
+}
+
+# Check available RAM for ramdisk
+# Args: $1 = required_gb
+# Returns: 0 if sufficient RAM, 1 otherwise
+check_available_ram() {
+    local required_gb="$1"
+    
+    # Get available memory in GB (MemAvailable from /proc/meminfo)
+    local available_kb
+    available_kb=$(grep MemAvailable /proc/meminfo | awk '{print $2}')
+    
+    # Convert to GB using awk for floating point
+    local available_gb
+    available_gb=$(awk "BEGIN {printf \"%.2f\", $available_kb / 1024 / 1024}")
+    
+    echo "Available RAM: ${available_gb} GB"
+    echo "Required for ramdisk: ${required_gb} GB"
+    
+    # Compare using awk for floating point
+    if awk "BEGIN {exit !($available_gb >= $required_gb)}"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Setup ramdisk for recording
+# Args: $1 = script_dir
+# Sets: RAMDISK_ACTIVE (0 or 1), RAMDISK_RECORDING_PATH
+# Returns: 0 on success, 1 on failure (falls back to disk)
+setup_ramdisk() {
+    local script_dir="$1"
+    
+    RAMDISK_ACTIVE=0
+    RAMDISK_RECORDING_PATH=""
+    
+    if ! is_ramdisk_enabled "$script_dir"; then
+        echo "Ramdisk: disabled in config"
+        return 1
+    fi
+    
+    get_ramdisk_config "$script_dir"
+    
+    echo "Ramdisk: checking availability..."
+    
+    # Check if we have enough RAM
+    if ! check_available_ram "$RAMDISK_SIZE_GB"; then
+        echo "⚠️  Ramdisk: insufficient RAM, falling back to disk"
+        return 1
+    fi
+    
+    # Create ramdisk directory
+    mkdir -p "$RAMDISK_PATH"
+    
+    # Check if already mounted as tmpfs
+    if mountpoint -q "$RAMDISK_PATH" 2>/dev/null; then
+        echo "Ramdisk: already mounted at $RAMDISK_PATH"
+    else
+        # Try to mount tmpfs (may require sudo)
+        local size_mb=$((RAMDISK_SIZE_GB * 1024))
+        if sudo mount -t tmpfs -o size=${size_mb}M tmpfs "$RAMDISK_PATH" 2>/dev/null; then
+            echo "✅ Ramdisk: mounted ${RAMDISK_SIZE_GB}GB tmpfs at $RAMDISK_PATH"
+        else
+            # Fallback: use /dev/shm which is typically already a tmpfs
+            if [ -d "/dev/shm" ]; then
+                RAMDISK_PATH="/dev/shm/multicam_ramdisk"
+                mkdir -p "$RAMDISK_PATH"
+                echo "✅ Ramdisk: using /dev/shm at $RAMDISK_PATH"
+            else
+                echo "⚠️  Ramdisk: mount failed, falling back to disk"
+                return 1
+            fi
+        fi
+    fi
+    
+    RAMDISK_ACTIVE=1
+    RAMDISK_RECORDING_PATH="$RAMDISK_PATH"
+    echo "Ramdisk: ready for recording"
+    return 0
+}
+
+# Get the recording path (ramdisk or disk)
+# Args: $1 = original_output_dir, $2 = fin_name
+# Returns: path to use for recording
+get_recording_path() {
+    local original_output_dir="$1"
+    local fin_name="$2"
+    
+    if [ "$RAMDISK_ACTIVE" -eq 1 ] && [ -n "$RAMDISK_RECORDING_PATH" ]; then
+        echo "$RAMDISK_RECORDING_PATH/$fin_name"
+    else
+        echo "$original_output_dir/$fin_name"
+    fi
+}
+
+# Move recordings from ramdisk to final destination
+# Args: $1 = ramdisk_path, $2 = final_path
+# Returns: 0 on success, 1 on failure
+move_from_ramdisk() {
+    local ramdisk_path="$1"
+    local final_path="$2"
+    
+    if [ "$RAMDISK_ACTIVE" -ne 1 ]; then
+        return 0  # Nothing to move
+    fi
+    
+    if [ ! -d "$ramdisk_path" ]; then
+        echo "⚠️  Ramdisk: source path does not exist: $ramdisk_path"
+        return 1
+    fi
+    
+    echo "Moving recordings from ramdisk to disk..."
+    echo "  From: $ramdisk_path"
+    echo "  To: $final_path"
+    
+    # Create final directory
+    mkdir -p "$final_path"
+    
+    # Move all files
+    local file_count=0
+    local total_size=0
+    
+    for file in "$ramdisk_path"/*; do
+        if [ -f "$file" ]; then
+            local filename=$(basename "$file")
+            local filesize=$(stat -c%s "$file" 2>/dev/null || echo 0)
+            total_size=$((total_size + filesize))
+            
+            echo "  Moving: $filename ($(numfmt --to=iec $filesize 2>/dev/null || echo "${filesize}B"))"
+            
+            if mv "$file" "$final_path/"; then
+                file_count=$((file_count + 1))
+            else
+                echo "❌ Failed to move: $filename"
+                return 1
+            fi
+        fi
+    done
+    
+    echo "✅ Moved $file_count files ($(numfmt --to=iec $total_size 2>/dev/null || echo "${total_size}B")) to disk"
+    
+    # Clean up ramdisk directory
+    rmdir "$ramdisk_path" 2>/dev/null
+    
+    return 0
+}
+
+# Cleanup ramdisk (unmount if we mounted it)
+# Args: $1 = script_dir
+cleanup_ramdisk() {
+    local script_dir="$1"
+    
+    if [ "$RAMDISK_ACTIVE" -ne 1 ]; then
+        return 0
+    fi
+    
+    get_ramdisk_config "$script_dir"
+    
+    # Only unmount if we mounted it (not /dev/shm)
+    if [ "$RAMDISK_PATH" != "/dev/shm/multicam_ramdisk" ]; then
+        if mountpoint -q "$RAMDISK_PATH" 2>/dev/null; then
+            echo "Ramdisk: unmounting $RAMDISK_PATH"
+            sudo umount "$RAMDISK_PATH" 2>/dev/null
+        fi
+    fi
+    
+    RAMDISK_ACTIVE=0
+}
+
+# Get ramdisk status for display
+# Args: $1 = script_dir
+get_ramdisk_status() {
+    local script_dir="$1"
+    
+    if ! is_ramdisk_enabled "$script_dir"; then
+        echo "disabled"
+        return
+    fi
+    
+    get_ramdisk_config "$script_dir"
+    
+    if [ "$RAMDISK_ACTIVE" -eq 1 ]; then
+        echo "active (${RAMDISK_SIZE_GB}GB at $RAMDISK_PATH)"
+    else
+        echo "enabled but not active"
+    fi
+}

--- a/tests/test_ramdisk_utils.sh
+++ b/tests/test_ramdisk_utils.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+
+# Test script for ramdisk_utils.sh functionality
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/ramdisk_utils.sh"
+
+# Test counters
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Test helper functions
+pass() {
+    echo "✅ PASS: $1"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+fail() {
+    echo "❌ FAIL: $1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+# Create temporary test config
+create_test_config() {
+    local enabled="$1"
+    local temp_dir="$2"
+    
+    cat > "$temp_dir/config.json" << EOF
+{
+  "disk_space": {
+    "min_free_space_gb": 10
+  },
+  "ramdisk": {
+    "enabled": $enabled,
+    "path": "$temp_dir/test_ramdisk",
+    "size_gb": 1
+  }
+}
+EOF
+}
+
+# Test: is_ramdisk_enabled with enabled=true
+test_is_ramdisk_enabled_true() {
+    local temp_dir=$(mktemp -d)
+    create_test_config "true" "$temp_dir"
+    
+    if is_ramdisk_enabled "$temp_dir"; then
+        pass "is_ramdisk_enabled returns true when enabled"
+    else
+        fail "is_ramdisk_enabled should return true when enabled"
+    fi
+    
+    rm -rf "$temp_dir"
+}
+
+# Test: is_ramdisk_enabled with enabled=false
+test_is_ramdisk_enabled_false() {
+    local temp_dir=$(mktemp -d)
+    create_test_config "false" "$temp_dir"
+    
+    if ! is_ramdisk_enabled "$temp_dir"; then
+        pass "is_ramdisk_enabled returns false when disabled"
+    else
+        fail "is_ramdisk_enabled should return false when disabled"
+    fi
+    
+    rm -rf "$temp_dir"
+}
+
+# Test: is_ramdisk_enabled with missing config
+test_is_ramdisk_enabled_no_config() {
+    local temp_dir=$(mktemp -d)
+    
+    if ! is_ramdisk_enabled "$temp_dir"; then
+        pass "is_ramdisk_enabled returns false when config missing"
+    else
+        fail "is_ramdisk_enabled should return false when config missing"
+    fi
+    
+    rm -rf "$temp_dir"
+}
+
+# Test: get_ramdisk_config
+test_get_ramdisk_config() {
+    local temp_dir=$(mktemp -d)
+    create_test_config "true" "$temp_dir"
+    
+    get_ramdisk_config "$temp_dir"
+    
+    if [ "$RAMDISK_PATH" = "$temp_dir/test_ramdisk" ]; then
+        pass "get_ramdisk_config sets RAMDISK_PATH correctly"
+    else
+        fail "get_ramdisk_config RAMDISK_PATH incorrect: $RAMDISK_PATH"
+    fi
+    
+    if [ "$RAMDISK_SIZE_GB" = "1" ]; then
+        pass "get_ramdisk_config sets RAMDISK_SIZE_GB correctly"
+    else
+        fail "get_ramdisk_config RAMDISK_SIZE_GB incorrect: $RAMDISK_SIZE_GB"
+    fi
+    
+    rm -rf "$temp_dir"
+}
+
+# Test: get_recording_path with ramdisk inactive
+test_get_recording_path_disk() {
+    RAMDISK_ACTIVE=0
+    RAMDISK_RECORDING_PATH=""
+    
+    local result=$(get_recording_path "/output" "test_recording")
+    
+    if [ "$result" = "/output/test_recording" ]; then
+        pass "get_recording_path returns disk path when ramdisk inactive"
+    else
+        fail "get_recording_path should return disk path: $result"
+    fi
+}
+
+# Test: get_recording_path with ramdisk active
+test_get_recording_path_ramdisk() {
+    RAMDISK_ACTIVE=1
+    RAMDISK_RECORDING_PATH="/tmp/ramdisk"
+    
+    local result=$(get_recording_path "/output" "test_recording")
+    
+    if [ "$result" = "/tmp/ramdisk/test_recording" ]; then
+        pass "get_recording_path returns ramdisk path when active"
+    else
+        fail "get_recording_path should return ramdisk path: $result"
+    fi
+    
+    # Reset
+    RAMDISK_ACTIVE=0
+    RAMDISK_RECORDING_PATH=""
+}
+
+# Test: move_from_ramdisk
+test_move_from_ramdisk() {
+    local temp_dir=$(mktemp -d)
+    local ramdisk_path="$temp_dir/ramdisk"
+    local final_path="$temp_dir/final"
+    
+    mkdir -p "$ramdisk_path"
+    echo "test content" > "$ramdisk_path/test_file.txt"
+    
+    RAMDISK_ACTIVE=1
+    
+    if move_from_ramdisk "$ramdisk_path" "$final_path"; then
+        if [ -f "$final_path/test_file.txt" ]; then
+            pass "move_from_ramdisk moves files correctly"
+        else
+            fail "move_from_ramdisk file not found in destination"
+        fi
+        
+        if [ ! -f "$ramdisk_path/test_file.txt" ]; then
+            pass "move_from_ramdisk removes source files"
+        else
+            fail "move_from_ramdisk should remove source files"
+        fi
+    else
+        fail "move_from_ramdisk returned error"
+    fi
+    
+    RAMDISK_ACTIVE=0
+    rm -rf "$temp_dir"
+}
+
+# Test: move_from_ramdisk when inactive
+test_move_from_ramdisk_inactive() {
+    RAMDISK_ACTIVE=0
+    
+    if move_from_ramdisk "/nonexistent" "/also_nonexistent"; then
+        pass "move_from_ramdisk returns success when inactive"
+    else
+        fail "move_from_ramdisk should return success when inactive"
+    fi
+}
+
+# Test: check_available_ram
+test_check_available_ram() {
+    # Test with very small requirement (should pass)
+    if check_available_ram "0.001" > /dev/null 2>&1; then
+        pass "check_available_ram passes with small requirement"
+    else
+        fail "check_available_ram should pass with small requirement"
+    fi
+    
+    # Test with impossibly large requirement (should fail)
+    if ! check_available_ram "999999" > /dev/null 2>&1; then
+        pass "check_available_ram fails with large requirement"
+    else
+        fail "check_available_ram should fail with large requirement"
+    fi
+}
+
+# Test: config.json has ramdisk section
+test_config_has_ramdisk() {
+    if [ -f "$SCRIPT_DIR/config.json" ]; then
+        local has_ramdisk=$(jq 'has("ramdisk")' "$SCRIPT_DIR/config.json" 2>/dev/null)
+        if [ "$has_ramdisk" = "true" ]; then
+            pass "config.json has ramdisk section"
+        else
+            fail "config.json missing ramdisk section"
+        fi
+    else
+        fail "config.json not found"
+    fi
+}
+
+# Run all tests
+echo "Running ramdisk_utils.sh tests..."
+echo ""
+
+test_is_ramdisk_enabled_true
+test_is_ramdisk_enabled_false
+test_is_ramdisk_enabled_no_config
+test_get_ramdisk_config
+test_get_recording_path_disk
+test_get_recording_path_ramdisk
+test_move_from_ramdisk
+test_move_from_ramdisk_inactive
+test_check_available_ram
+test_config_has_ramdisk
+
+echo ""
+echo "================================"
+echo "Tests passed: $TESTS_PASSED"
+echo "Tests failed: $TESTS_FAILED"
+echo "================================"
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo "✅ All tests passed!"
+    exit 0
+else
+    echo "❌ Some tests failed!"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Addresses #58 - When recording is disk I/O limited, recordings can now be written to a ramdisk (tmpfs) and moved to disk after recording completes.

## Changes

- **ramdisk_utils.sh**: New utility script with functions for:
  - Checking if ramdisk is enabled in config
  - Verifying available RAM before setup
  - Setting up tmpfs mount (with fallback to /dev/shm)
  - Moving files from ramdisk to final destination after recording
  - Cleanup on completion

- **config.json**: Added `ramdisk` configuration section:
  ```json
  "ramdisk": {
    "enabled": false,
    "path": "/tmp/multicam_ramdisk",
    "size_gb": 4
  }
  ```

- **parallel2video_ffmpeg.sh** and **parallel2video_streamer.sh**: Updated to:
  - Source ramdisk utilities
  - Record to ramdisk when enabled and RAM is available
  - Move files to final destination after recording completes
  - Handle cleanup on both normal exit and Ctrl+C interrupt

- **tests/test_ramdisk_utils.sh**: Test suite covering all ramdisk functions

## Usage

1. Enable ramdisk in `config.json`:
   ```json
   "ramdisk": {
     "enabled": true,
     "path": "/tmp/multicam_ramdisk",
     "size_gb": 4
   }
   ```

2. Run recording as normal - the script will:
   - Check if sufficient RAM is available
   - Record to ramdisk if possible, otherwise fall back to disk
   - Move files to final destination after recording

## Testing

All 13 tests pass:
```
bash tests/test_ramdisk_utils.sh
```